### PR TITLE
Pass diff exit code up to shell for test suite

### DIFF
--- a/tests/runtest
+++ b/tests/runtest
@@ -334,3 +334,4 @@ then
 	echo "All tests passed."
 fi
 
+exit $RET


### PR DESCRIPTION
Right now, test failures are not getting detected because the runtests script does not pass up a failing exit code from diff.